### PR TITLE
nextStateID in FSM might be  -2147483648 in practice, so fix it

### DIFF
--- a/integration/unity/Assets/Scripts/behaviac/runtime/FSM/FSM.cs
+++ b/integration/unity/Assets/Scripts/behaviac/runtime/FSM/FSM.cs
@@ -131,7 +131,7 @@ namespace behaviac
 
                     int nextStateId = currentState.GetNextStateId();
 
-                    if (nextStateId == -1)
+                    if (nextStateId < 0) // -1 or overflow
                     {
                         //if not transitioned, don't go on next state, to exit
                         bLoop = false;

--- a/src/fsm/fsm.cpp
+++ b/src/fsm/fsm.cpp
@@ -130,7 +130,7 @@ namespace behaviac
 
 			int nextStateId = currentState->GetNextStateId();
 
-			if (nextStateId == -1)
+			if (nextStateId < 0) // don't know why, the nextStateID might be -2147483648, so change the condition
 			{
 				//if not transitioned, don't go on next state, to exit
 				bLoop = false;


### PR DESCRIPTION
// 修复 nextStateId 溢出时影响状态机的 BUG:
don't know why, the nextStateID might be -2147483648, so change the condition